### PR TITLE
Various bug fixes

### DIFF
--- a/.github/workflows/adp.yaml
+++ b/.github/workflows/adp.yaml
@@ -2,6 +2,9 @@ name: adp
 
 on: workflow_dispatch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   process-reference-files:
     runs-on: ubuntu-latest

--- a/actions-bin/adp.py
+++ b/actions-bin/adp.py
@@ -149,11 +149,10 @@ with open(PATHNAME, "r", encoding="utf-8") as f:
                     ref_set.add(oldref.get("url"))
                 # We should stop searching right after, at worst o(n)
                 break
-
+    REQUIRE_PUT = False
+    url_put = f"{BASE_SERVICES_URL}{reference_cve_id}/adp"
     if reference_url not in ref_set:
         print(f"{reference_cve_id}: found reference {reference_url} is new")
-
-        url_put = f"{BASE_SERVICES_URL}{reference_cve_id}/adp"
 
         if old_adp_container:
             if "references" in old_adp_container:
@@ -164,7 +163,27 @@ with open(PATHNAME, "r", encoding="utf-8") as f:
             new_json_data = {"adpContainer": {"references": old_adp_container["references"]}}
         else:
             new_json_data = {"adpContainer": {"references": [{"url": reference_url}]}}
+        REQUIRE_PUT = True
+    else:
+        # The reference is already in the ADP container, but we need to check to see if the reference has a tag called cve_prog_secretariat_snapshot
+        # Safety check
+        if old_adp_container:
+            for oldref in old_adp_container["references"]:
+                if oldref.get("url") == reference_url:
+                    if "tags" in oldref:
+                        if "cve_prog_secretariat_snapshot" in oldref["tags"]:
+                            print(
+                                f"{reference_cve_id}: found reference {reference_url} has tag x_cve_prog_secretariat_snapshot"
+                            )
+                            oldref["tags"].remove("x_cve_prog_secretariat_snapshot")
+                            REQUIRE_PUT = True
+                            break
+                    else:
+                        print(f"{reference_cve_id}: found reference {reference_url} has no tags")
+                        REQUIRE_PUT = False
+                        break
 
+    if REQUIRE_PUT:
         print(f"{reference_cve_id}: Doing PUT of ADP container {json.dumps(new_json_data)}")
 
         put_request = send_put_request(url_put, headers, new_json_data)

--- a/actions-bin/adp.py
+++ b/actions-bin/adp.py
@@ -1,6 +1,8 @@
+# pylint: disable=C0301
 """
 File is run by a github action to save processed reference file to save the reference to a MITRE owned ADP.
 """
+
 import sys
 import os
 import json
@@ -61,7 +63,7 @@ with open(PATHNAME, "r", encoding="utf-8") as f:
     reference_cve_id = obj["id"]
 
     # TODO: Move this to env vars possibly?
-    
+
     headers = {
         "Content-type": "application/json",
         "CVE-API-ORG": os.environ["CVE-API-ORG"],
@@ -78,48 +80,49 @@ with open(PATHNAME, "r", encoding="utf-8") as f:
     # fake_cve = "CVE-2023-2103" + reference_cve_id[-1]
     # CVE_CHECK_URL = BASE_SERVICES_URL + fake_cve
 
-    # First attemp at
+    # First attempt at
     request = send_get_request(CVE_CHECK_URL=CVE_CHECK_URL)
     print(f"request: {request.status_code}, {CVE_CHECK_URL}, {request.text}")
-    if request.status_code == 200 and request.json().get("cveMetadata", {}).get("state") == "REJECTED":
-        print("The CVE Record for the CVE ID is in the REJECTED state and cannot have an ADP container.")
-        sys.exit(1)
-    if request.status_code == 404 and "CVE_RECORD_DNE" in request.text:
-        print("The cve record for the cve id does not exist.")
-        sys.exit(1)
+    # This is very verbose, but this code should be clear and easy to follow.
     # If first request fails for network issues, do a quick retry. As per content team's request
-    if not request:
+    # Need to check for None or 500 status code (ensure to check the request object first, so we don't unwrap a None).
+    if not request or request.status_code == 500:
         print(f"{reference_cve_id}: GET Failed to get record from CVE-services for networks issues. Retrying")
         request = send_get_request(CVE_CHECK_URL=CVE_CHECK_URL)
+        # Second request attempt did not return a request object, this is failure.
         if not request:
             print(f"{reference_cve_id}: GET Failed to get record from CVE-services twice for network issues. EXITING")
             sys.exit(1)
 
-    # First request attempt returned a request object
+        # Second request attempt returned a request object, but we want to check the status code.
+        # Logging again to ensure we know it is the second attempt for debugging purposes.
+        if request.status_code == 500:
+            print(f"{reference_cve_id}: GET Failed to get record from CVE-services twice for 500 status code. EXITING")
+            sys.exit(1)
+        if request.status_code == 200 and request.json().get("cveMetadata", {}).get("state") == "REJECTED":
+            print(
+                "On second request found the CVE Record for the CVE ID is in the REJECTED state and cannot have an ADP container."
+            )
+            sys.exit(1)
+        if request.status_code == 404 and "CVE_RECORD_DNE" in request.text:
+            print("On second request found the cve record for the cve id does not exist.")
+            sys.exit(1)
+    else:
+        # First Request returned and it has a status code not 500, need to check between 200 and 404 for correct state management and debug output.
+        if request.status_code == 200 and request.json().get("cveMetadata", {}).get("state") == "REJECTED":
+            print("The CVE Record for the CVE ID is in the REJECTED state and cannot have an ADP container.")
+            sys.exit(1)
+        if request.status_code == 404 and "CVE_RECORD_DNE" in request.text:
+            print("The cve record for the cve id does not exist.")
+            sys.exit(1)
+
     request_status_code = request.status_code
+    # This check is a failsafe, we should never fail here, but just in case.
     if request_status_code != 200:
         print(
-            f"{reference_cve_id}: GET status {str(request_status_code)} Failed to get record from CVE-services for a bad status code, Attempting to retry."
+            f"{reference_cve_id}: GET status {str(request_status_code)} Failed to get record CVE-services for a bad status code."
         )
-
-        request = send_get_request(CVE_CHECK_URL=CVE_CHECK_URL)
-        # Request object is None, IE: The reqeust failed for network issues
-        if not request:
-            print(f"{reference_cve_id}: GET Failed to get record from CVE-services twice for network issues. EXITING")
-            sys.exit(1)
-        else:
-            # Request returned, need to check status code
-            request_status_code = request.status_code
-            if request_status_code == 404:
-                print(f"{reference_cve_id} not found (may be RBP); cannot add ADP container")
-                sys.exit(1)
-            elif request_status_code != 200:
-                print(
-                    f"{reference_cve_id} published record was not successfully retrieved ({request_status_code}); cannot add ADP container"
-                )
-                sys.exit(1)
-            # If the code gets here, the request should be 200
-            # Fall out
+        sys.exit(1)
 
     # Request should have a valid CVE object
     request_json = request.json()
@@ -129,13 +132,13 @@ with open(PATHNAME, "r", encoding="utf-8") as f:
     old_adp_container = None
 
     ref_set = set()
-    
+
     if "cna" in request_json.get("containers"):
         cna_references = request_json.get("containers").get("cna").get("references", [])
         for cna_reference in cna_references:
             print(f"{reference_cve_id} from CNA: {cna_reference.get('url')}")
             ref_set.add(cna_reference.get("url"))
-    
+
     if "adp" in request_json.get("containers"):
         for container in request_json.get("containers").get("adp"):
             # TODO: Make this be compared to a var at some point.


### PR DESCRIPTION
1. Locks the workflow to only allow one instance of the workflow to run at once. This will keep the workflow waiting if a long running instance processing a lot of data takes a whole "cycle".
2. Reworks the first group of calls to CVE-Services in the adp.py file to protect against a null unwrapping. We were also doing a whole extra check that was unneeded. 