### PR TITLE
clarify that ref_set elements come from two containers

### DIFF
--- a/actions-bin/adp.py
+++ b/actions-bin/adp.py
@@ -158,7 +158,7 @@ with open(PATHNAME, "r", encoding="utf-8") as f:
             new_json_data = {"adpContainer": {"title": "Secretariat Program Container","references": [{"url": reference_url}]}}
         REQUIRE_PUT = True
     else:
-        # The reference is already in the ADP container, but we need to check to see if the reference has a tag called cve_prog_secretariat_snapshot
+        # The reference is already in the ADP or CNA container, but we need to check to see if the reference has a tag called cve_prog_secretariat_snapshot
         # Safety check
         print (f"{reference_cve_id}: found reference {reference_url} is already in the ADP container")
         if old_adp_container:


### PR DESCRIPTION
The `else` of `if reference_url not in ref_set` says "The reference is already in the ADP container" but it might have been only in the CNA container.