### PR TITLE
KeyError if ADP container does not have a references property

### DIFF
--- a/actions-bin/adp.py
+++ b/actions-bin/adp.py
@@ -163,6 +163,7 @@ with open(PATHNAME, "r", encoding="utf-8") as f:
         print (f"{reference_cve_id}: found reference {reference_url} is already in the ADP container")
         if old_adp_container:
             print(f"{reference_cve_id}: found old_adp_container {json.dumps(old_adp_container)}")
+            # this will have a KeyError if old_adp_container has no references property
             for oldref in old_adp_container["references"]:
                 if oldref.get("url") == reference_url:
                     if "tags" in oldref:


### PR DESCRIPTION
In realistic cases, Secretariat ADP containers retrieved from CVE Services will have no references property, because they originated later than the containers created with x_transferred references, and all of the references have been removed by the content team.

```
import json

# set up realistic test value of old_adp_container

old_adp_container = {"providerMetadata": {}}
old_adp_container["providerMetadata"]["orgId"] = "00000000-0000-4000-9000-000000000000"
old_adp_container["providerMetadata"]["shortName"] = "Secretariat-Container"
old_adp_container["timeline"] = []
entry = {}
entry["time"] = "2024-07-15T00:00:00Z"
entry["lang"] = "en"
entry["value"] = "Previously entered references were removed because they are not applicable to this CVE Record."
old_adp_container["timeline"].append(entry)

# set up variables used by adp.py

reference_cve_id = "CVE-1900-0001"
reference_url = "https://example.com"

# run part of adp.py code

if old_adp_container:
    print(f"{reference_cve_id}: found old_adp_container {json.dumps(old_adp_container)}")
    for oldref in old_adp_container["references"]:
        if oldref.get("url") == reference_url:
            if "tags" in oldref:
                if "x_transferred" in oldref["tags"]:
                    print(
                        f"{reference_cve_id}: found reference {reference_url} has tag x_transferred"
                    )
                    oldref["tags"].remove("x_transferred")
                    if len(oldref["tags"]) <= 0:
                        del oldref["tags"]
                    new_json_data = {"adpContainer": old_adp_container}
                    REQUIRE_PUT = True
                    break
            else:
                print(f"{reference_cve_id}: found reference {reference_url} has no tags")
                REQUIRE_PUT = False
                break
else:
    print("no old_adp_container")
```
```
outcome:

CVE-1900-0001: found old_adp_container {"providerMetadata": {"orgId":
  "00000000-0000-4000-9000-000000000000", "shortName": "Secretariat-Container"},
  "timeline": [{"time": "2024-07-15T00:00:00Z", "lang": "en", "value":
  "Previously entered references were removed because they are not applicable to this CVE Record."}]}
Traceback (most recent call last):
  File "./adp-test.py", line 25, in <module>
    for oldref in old_adp_container["references"]:
KeyError: 'references'
```