### PR TITLE
x_transferred not removed if two elements have same reference URL

### DIFF
--- a/actions-bin/adp.py
+++ b/actions-bin/adp.py
@@ -175,6 +175,7 @@ with open(PATHNAME, "r", encoding="utf-8") as f:
                                 del oldref["tags"]
                             new_json_data = {"adpContainer": old_adp_container}    
                             REQUIRE_PUT = True
+                            # this break does not consider other instances of the same reference URL with x_transferred
                             break
                     else:
                         print(f"{reference_cve_id}: found reference {reference_url} has no tags")


### PR DESCRIPTION
If there are two elements of the references array with the same URL, x_transferred is only removed from one of them. A CNA is allowed to place the same reference URL multiple times in the references array, as long as the tags are non-identical. Thus, among the original set of CVE Records with x_transferred references, there may be some with multiple instances of x_transferred for the same URL.
```
import json

# set up plausible test value of old_adp_container

old_adp_container = {"providerMetadata": {}}
old_adp_container["providerMetadata"]["orgId"] = "00000000-0000-4000-9000-000000000000"
old_adp_container["providerMetadata"]["shortName"] = "Secretariat-Container"
old_adp_container["references"] = []
old_adp_container["references"].append({"tags": ["x_one"], "url":"https://example.com"})
old_adp_container["references"].append({"tags": ["x_transferred", "x_two"], "url":"https://example.com"})
old_adp_container["references"].append({"tags": ["x_transferred", "x_three"], "url":"https://example.com"})
old_adp_container["references"].append({"tags": ["x_four"], "url":"https://example.com"})

# set up variables used by adp.py

reference_cve_id = "CVE-1900-0001"
reference_url = "https://example.com"
new_json_data = "{}"

# run part of adp.py code

if old_adp_container:
    print(f"{reference_cve_id}: found old_adp_container {json.dumps(old_adp_container)}")
    for oldref in old_adp_container["references"]:
        if oldref.get("url") == reference_url:
            if "tags" in oldref:
                if "x_transferred" in oldref["tags"]:
                    print(
                        f"{reference_cve_id}: found reference {reference_url} has tag x_transferred"
                    )
                    oldref["tags"].remove("x_transferred")
                    if len(oldref["tags"]) <= 0:
                        del oldref["tags"]
                    new_json_data = {"adpContainer": old_adp_container}
                    REQUIRE_PUT = True
                    break
            else:
                print(f"{reference_cve_id}: found reference {reference_url} has no tags")
                REQUIRE_PUT = False
                break
else:
    print("no old_adp_container")

j = json.dumps(new_json_data)
print(f'new_json_data: {j}')
```
```
outcome:

CVE-1900-0001: found old_adp_container {"providerMetadata": {"orgId":
  "00000000-0000-4000-9000-000000000000", "shortName": "Secretariat-Container"},
  "references": [{"tags": ["x_one"], "url": "https://example.com"},
  {"tags": ["x_transferred", "x_two"], "url": "https://example.com"},
  {"tags": ["x_transferred", "x_three"], "url": "https://example.com"},
  {"tags": ["x_four"], "url": "https://example.com"}]}
CVE-1900-0001: found reference https://example.com has tag x_transferred
new_json_data: {"adpContainer": {"providerMetadata": {"orgId":
  "00000000-0000-4000-9000-000000000000", "shortName": "Secretariat-Container"},
  "references": [{"tags": ["x_one"], "url": "https://example.com"},
  {"tags": ["x_two"], "url": "https://example.com"},
  {"tags": ["x_transferred", "x_three"], "url": "https://example.com"},
  {"tags": ["x_four"], "url": "https://example.com"}]}}

```