### PR TITLE
comment mentions cve_prog_secretariat_snapshot

### DIFF
--- a/actions-bin/adp.py
+++ b/actions-bin/adp.py
@@ -158,7 +158,7 @@ with open(PATHNAME, "r", encoding="utf-8") as f:
             new_json_data = {"adpContainer": {"title": "Secretariat Program Container","references": [{"url": reference_url}]}}
         REQUIRE_PUT = True
     else:
-        # The reference is already in the ADP container, but we need to check to see if the reference has a tag called cve_prog_secretariat_snapshot
+        # The reference is already in the ADP container, but we need to check to see if the reference has a tag called x_transferred
         # Safety check
         print (f"{reference_cve_id}: found reference {reference_url} is already in the ADP container")
         if old_adp_container:


### PR DESCRIPTION
A comment mentions
```
tag called cve_prog_secretariat_snapshot
```
but this is not the tag name (`x_transferred`) used by the current code.