### PR TITLE
oldref["tags"].remove can violate JSON schema

### DIFF
--- a/actions-bin/adp.py
+++ b/actions-bin/adp.py
@@ -170,6 +170,7 @@ with open(PATHNAME, "r", encoding="utf-8") as f:
                             print(
                                 f"{reference_cve_id}: found reference {reference_url} has tag x_transferred"
                             )
+                            # this remove can cause a schema violation (duplicate array elements)
                             oldref["tags"].remove("x_transferred")
                             if len(oldref["tags"]) <= 0:
                                 del oldref["tags"]


### PR DESCRIPTION
If the ADP container has two similar references (differing only in that one has an x_transferred tag and the other does not), then the call to oldref["tags"].remove can result in a JSON document that does not comply with the schema for the CVE Record format, because the references array then has two items that are identical (the same URL and the same set of zero or more remaining tags). The send_put_request call will then fail.

Possibly the entire ` found reference {reference_url} is already in the ADP container` code is not normally reachable. .github/workflows/adp.yaml is trying to gather new information, not a pair of obj["URL"] and obj["id"] that has already been gathered in the past.
```
import json

# set up plausible test value of old_adp_container

old_adp_container = {"providerMetadata": {}}
old_adp_container["providerMetadata"]["orgId"] = "00000000-0000-4000-9000-000000000000"
old_adp_container["providerMetadata"]["shortName"] = "CVE"
old_adp_container["references"] = []
old_adp_container["references"].append({"tags": ["x_one", "x_transferred"], "url":"https://example.com"})
old_adp_container["references"].append({"tags": ["x_one"], "url":"https://example.com"})

# set up variables used by adp.py

reference_cve_id = "CVE-1900-0001"
reference_url = "https://example.com"
new_json_data = "{}"

# run part of adp.py code

if old_adp_container:
    print(f"{reference_cve_id}: found old_adp_container {json.dumps(old_adp_container)}")
    for oldref in old_adp_container["references"]:
        if oldref.get("url") == reference_url:
            if "tags" in oldref:
                if "x_transferred" in oldref["tags"]:
                    print(
                        f"{reference_cve_id}: found reference {reference_url} has tag x_transferred"
                    )
                    oldref["tags"].remove("x_transferred")
                    if len(oldref["tags"]) <= 0:
                        del oldref["tags"]
                    new_json_data = {"adpContainer": old_adp_container}
                    REQUIRE_PUT = True
                    break
            else:
                print(f"{reference_cve_id}: found reference {reference_url} has no tags")
                REQUIRE_PUT = False
                break
else:
    print("no old_adp_container")

j = json.dumps(new_json_data)
print(f'new_json_data: {j}')
```
```
outcome (JSON document)

new_json_data: {"adpContainer": {"providerMetadata":
{"orgId": "00000000-0000-4000-9000-000000000000", "shortName": "CVE"},
"references": [{"tags": ["x_one"], "url": "https://example.com"},
{"tags": ["x_one"], "url": "https://example.com"}]}}

outcome (server response)

{"error":"INVALID_JSON_SCHEMA","message":"CVE JSON schema validation FAILED.",
"details":{"errors":[{"instancePath":"/containers/adp/0/references",
"schemaPath":"#/uniqueItems","keyword":"uniqueItems","params":{"i":1,"j":0},
"message":"must NOT have duplicate items (items ## 0 and 1 are identical)"}
```