### PR TITLE
references can be added that duplicate the CNA container

### DIFF
--- a/actions-bin/adp.py
+++ b/actions-bin/adp.py
@@ -167,6 +167,7 @@ with open(PATHNAME, "r", encoding="utf-8") as f:
                 print ("Currently not checking for tag removal")
             else:
                 # The case where the ADP container exists, but did not have the reference key.
+                # There should not be a PUT in this case, because reference_url is in ref_set.
                 old_adp_container["references"] = [{"url": reference_url}]
                 new_json_data = {"adp_container": old_adp_container}
                 REQUIRE_PUT = True


### PR DESCRIPTION
One of the REQUIRE_PUT True cases occurs when the new reference URL is already in the CNA container, but the ADP container does not have a references property. This is not correct. A reference that is currently in the CNA container is never supposed to be added to the ADP container.

It appears that this is a recently added behavior, e.g., https://github.com/CVEProject/cve-reference-ingest/blob/d9424688044d884a86fe9d0ec014fd98e92e191a/actions-bin/adp.py did not do this. There are currently no situations where REQUIRE_PUT is supposed to be set to True within the "The reference is already in the ADP or CNA container" code block.
```
import json

# set up realistic test value of the containers property (in practice,
# the CNA container would also have other properties that are
# irrelevant to this example)

containers_from_get_api = {"cna": {}, "adp": []}
containers_from_get_api["cna"]["references"] = []
containers_from_get_api["cna"]["references"].append({"url": "https://example.com"})

containers_from_get_api["adp"].append({"providerMetadata": {}})
containers_from_get_api["adp"][0]["providerMetadata"]["orgId"] = "00000000-0000-4000-9000-000000000000"
containers_from_get_api["adp"][0]["providerMetadata"]["shortName"] = "CVE"
containers_from_get_api["adp"][0]["timeline"] = []
entry = {}
entry["time"] = "2024-07-27T00:00:00Z"
entry["lang"] = "en"
entry["value"] = "Previously entered references were removed because they are not applicable to this CVE Record."
containers_from_get_api["adp"][0]["timeline"].append(entry)

# set up variables used by adp.py

reference_cve_id = "CVE-1900-0001"
reference_url = "https://example.com"

# run part of the adp.py code

old_adp_container = None

ref_set = set()

if "cna" in containers_from_get_api:
    cna_references = containers_from_get_api.get("cna").get("references", [])
    for cna_reference in cna_references:
        print(f"{reference_cve_id} from CNA: {cna_reference.get('url')}")
        ref_set.add(cna_reference.get("url"))

if "adp" in containers_from_get_api:
    for container in containers_from_get_api.get("adp"):
        if container.get("providerMetadata").get("shortName") == "CVE":
            old_adp_container = container
            for oldref in container.get("references", []):
                print(f"{reference_cve_id} from ADP: {oldref.get('url')}")
                ref_set.add(oldref.get("url"))
            # We should stop searching right after, at worst o(n)
            break
REQUIRE_PUT = False

if reference_url not in ref_set:
    print(f"{reference_cve_id}: found reference {reference_url} is new")

    if old_adp_container:
        if "references" in old_adp_container:
            old_adp_container["references"].append({"url": reference_url})
        else:
            old_adp_container["references"] = [{"url": reference_url}]

        new_json_data = {"adpContainer": {"title": "CVE Program Container","references": old_adp_container["references"]}}
    else:
        new_json_data = {"adpContainer": {"title": "CVE Program Container","references": [{"url": reference_url}]}}
    REQUIRE_PUT = True
else:
    # The reference is already in the ADP or CNA container, but we need to check to see if the reference has a tag called x_transferred
    # Safety check
    print (f"{reference_cve_id}: found reference {reference_url} is already in the ADP or CNA container")
    if old_adp_container:
        print(f"{reference_cve_id}: found old_adp_container {json.dumps(old_adp_container)}")
        if "references" in old_adp_container.keys():
            print ("Currently not checking for tag removal")
        else:
            # The case where the ADP container exists, but did not have the reference key.
            old_adp_container["references"] = [{"url": reference_url}]
            new_json_data = {"adp_container": old_adp_container}
            REQUIRE_PUT = True
    else:
        print("no old_adp_container")
print (f"{reference_cve_id}: REQUIRE_PUT: {REQUIRE_PUT}")
if REQUIRE_PUT:
    print(f"{reference_cve_id}: Doing PUT of ADP container {json.dumps(new_json_data)}")
```
```
outcome:

CVE-1900-0001 from CNA: https://example.com
CVE-1900-0001: found reference https://example.com is already in the ADP or CNA container
CVE-1900-0001: found old_adp_container {"providerMetadata": {"orgId":
    "00000000-0000-4000-9000-000000000000", "shortName": "CVE"},
    "timeline": [{"time": "2024-07-27T00:00:00Z", "lang": "en", "value":
    "Previously entered references were removed because they are not applicable to this CVE Record."}]}
CVE-1900-0001: REQUIRE_PUT: True
CVE-1900-0001: Doing PUT of ADP container {"adp_container": {"providerMetadata":
    {"orgId": "00000000-0000-4000-9000-000000000000", "shortName": "CVE"},
    "timeline": [{"time": "2024-07-27T00:00:00Z", "lang": "en", "value":
    "Previously entered references were removed because they are not applicable to this CVE Record."}],
    "references": [{"url": "https://example.com"}]}}
```